### PR TITLE
fix: filter self-refs in replan dep remapping

### DIFF
--- a/src/luna_os/planner.py
+++ b/src/luna_os/planner.py
@@ -615,8 +615,9 @@ Report results to: {chat_id}
 
         for i, ns in enumerate(new_steps):
             raw_deps = ns.get("depends_on") or []
-            deps = [d + next_num for d in raw_deps]
-            self.store.insert_step(plan.id, next_num + i, ns["title"], ns["prompt"], deps)
+            step_num = next_num + i
+            deps = [d + next_num for d in raw_deps if d + next_num != step_num]
+            self.store.insert_step(plan.id, step_num, ns["title"], ns["prompt"], deps)
 
         # Auto-advance if plan is active
         spawn_ok = False


### PR DESCRIPTION
Small follow-up to #8. replan() remaps 0-indexed deps but didn't filter self-references after remapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency handling in the planning system to prevent invalid self-references, improving step scheduling accuracy and execution flow during replanning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->