### PR TITLE
fix: normalize_step accepts 'description' as title/prompt key

### DIFF
--- a/src/luna_os/planner.py
+++ b/src/luna_os/planner.py
@@ -67,8 +67,14 @@ def _short_desc(text: str, max_len: int = 60) -> str:
 
 def normalize_step(raw: dict[str, Any]) -> dict[str, Any]:
     """Normalize step input to ``{title, prompt, depends_on}`` format."""
-    title = raw.get("title") or raw.get("desc") or raw.get("name") or "Untitled"
-    prompt = raw.get("prompt") or raw.get("detail") or ""
+    title = (
+        raw.get("title")
+        or raw.get("description")
+        or raw.get("desc")
+        or raw.get("name")
+        or "Untitled"
+    )
+    prompt = raw.get("prompt") or raw.get("detail") or raw.get("description") or ""
     depends_on = raw.get("depends_on")
     if depends_on is None:
         depends_on = []

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -291,6 +291,16 @@ class TestNormalizeStep:
         assert step["title"] == "Do it"
         assert step["prompt"] == "Details"
 
+    def test_normalize_description_key(self):
+        step = normalize_step({"description": "步骤一描述", "depends_on": []})
+        assert step["title"] == "步骤一描述"
+        assert step["prompt"] == "步骤一描述"
+
+    def test_normalize_description_as_prompt_fallback(self):
+        step = normalize_step({"title": "My Step", "description": "Detailed desc"})
+        assert step["title"] == "My Step"
+        assert step["prompt"] == "Detailed desc"
+
     def test_normalize_deps_int(self):
         step = normalize_step({"title": "X", "depends_on": 0})
         assert step["depends_on"] == [0]


### PR DESCRIPTION
传 `{description: '步骤描述'}` 时步骤显示 Untitled，因为 normalize_step 只认 title/desc/name。现在 description 同时作为 title 和 prompt 的 fallback。