### PR TITLE
fix: graph clipped when all steps are independent

### DIFF
--- a/src/luna_os/timeline.py
+++ b/src/luna_os/timeline.py
@@ -252,6 +252,7 @@ if (independent.length > 0) {{
         col++;
     }});
     phasedStartY = curY + rowH + baseRowGap + 10;
+    totalH = Math.max(totalH, curY + rowH + gapY);
 
     // Divider line
     if (phased.length > 0) {{


### PR DESCRIPTION
totalH 在只有 independent 步骤（无 phased）时没有更新，导致截图截断底部 node。加一行 totalH 更新。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timeline layout height calculation to properly account for independent steps within the layout. The canvas now displays at the correct overall height, improving visual alignment and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->