### PR TITLE
fix: extract and save token costs from agent sessions

### DIFF
--- a/src/luna_os/planner.py
+++ b/src/luna_os/planner.py
@@ -1245,6 +1245,19 @@ Report results to: {chat_id}
                     if existing and existing.task_id:
                         task = self.store.get_task(existing.task_id)
                         if task and task.status.value != "failed":
+                            # Extract token costs before failing
+                            if task.session_key:
+                                from luna_os.events import (
+                                    _extract_session_cost,
+                                )
+
+                                inp, out, cost = _extract_session_cost(
+                                    task.session_key,
+                                )
+                                if inp or out or cost:
+                                    self.store.update_task_cost(
+                                        existing.task_id, inp, out, cost,
+                                    )
                             self.store.fail_task(existing.task_id, fail_reason)
                     updated_plan = self.store.get_plan(full.id)
                     if updated_plan:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,15 @@
 """Tests for the events module."""
 
-from luna_os.events import ContractHelper, process_events, resolve_plan_for_task
+import json
+import os
+import tempfile
+
+from luna_os.events import (
+    ContractHelper,
+    _extract_session_cost,
+    process_events,
+    resolve_plan_for_task,
+)
 from tests.memory_store import MemoryBackend
 
 
@@ -108,3 +117,94 @@ class TestProcessEvents:
         assert len(store.poll_events()) == 1
         process_events(store)
         assert len(store.poll_events()) == 0
+
+
+class TestExtractSessionCost:
+    def test_extract_from_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["OPENCLAW_SESSIONS_DIR"] = tmpdir
+            try:
+                lines = [
+                    json.dumps({
+                        "type": "message",
+                        "message": {
+                            "role": "assistant",
+                            "usage": {
+                                "input": 1000,
+                                "output": 200,
+                                "cost": {"total": 0.05},
+                            },
+                        },
+                    }),
+                    json.dumps({
+                        "type": "message",
+                        "message": {
+                            "role": "assistant",
+                            "usage": {
+                                "input": 2000,
+                                "output": 300,
+                                "cost": {"total": 0.10},
+                            },
+                        },
+                    }),
+                    json.dumps({"type": "session", "id": "test"}),
+                ]
+                with open(os.path.join(tmpdir, "test-key.jsonl"), "w") as f:
+                    f.write("\n".join(lines))
+
+                inp, out, cost = _extract_session_cost("test-key")
+                assert inp == 3000
+                assert out == 500
+                assert abs(cost - 0.15) < 0.001
+            finally:
+                os.environ.pop("OPENCLAW_SESSIONS_DIR", None)
+
+    def test_missing_session_returns_zero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["OPENCLAW_SESSIONS_DIR"] = tmpdir
+            try:
+                inp, out, cost = _extract_session_cost("nonexistent")
+                assert inp == 0
+                assert out == 0
+                assert cost == 0.0
+            finally:
+                os.environ.pop("OPENCLAW_SESSIONS_DIR", None)
+
+    def test_path_traversal_blocked(self):
+        inp, out, cost = _extract_session_cost("../../../etc/passwd")
+        assert inp == 0
+
+
+class TestContractHelperCost:
+    def test_done_updates_task_cost(self):
+        store = MemoryBackend()
+        store.add_task("t-1", "test task")
+        store.start_task("t-1", "test-session")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["OPENCLAW_SESSIONS_DIR"] = tmpdir
+            try:
+                with open(
+                    os.path.join(tmpdir, "test-session.jsonl"), "w"
+                ) as f:
+                    f.write(json.dumps({
+                        "type": "message",
+                        "message": {
+                            "role": "assistant",
+                            "usage": {
+                                "input": 5000,
+                                "output": 800,
+                                "cost": {"total": 0.25},
+                            },
+                        },
+                    }))
+
+                ch = ContractHelper(store, task_id="t-1")
+                ch.done("completed")
+
+                task = store.get_task("t-1")
+                assert task.input_tokens == 5000
+                assert task.output_tokens == 800
+                assert abs(task.cost_usd - 0.25) < 0.001
+            finally:
+                os.environ.pop("OPENCLAW_SESSIONS_DIR", None)


### PR DESCRIPTION
Closes #21

Agent session 有完整的 token 使用数据（在 jsonl 文件里），但从未回写到 task store，导致 `luna-os task status` 显示 tokens=0，看起来像 agent 没执行。

修复：`ContractHelper.done()/fail()` 自动从 session jsonl 提取 token 总量并调用 `update_task_cost`。stuck detection auto-fail 时也提取。

4 个新测试覆盖 jsonl 解析、缺失文件、路径遍历防护、done() 回写。