### PR TITLE
fix: notify main session on every plan state change + deliver results

### DIFF
--- a/src/luna_os/agents/base.py
+++ b/src/luna_os/agents/base.py
@@ -9,7 +9,13 @@ class AgentRunner(ABC):
     """Abstract interface for spawning and managing agent sessions."""
 
     @abstractmethod
-    def spawn(self, task_id: str, prompt: str, session_label: str = "") -> str:
+    def spawn(
+        self,
+        task_id: str,
+        prompt: str,
+        session_label: str = "",
+        reply_chat_id: str = "",
+    ) -> str:
         """Spawn an agent session. Return a session key / identifier."""
 
     @abstractmethod

--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -16,7 +16,13 @@ class OpenClawRunner(AgentRunner):
     def __init__(self, binary: str = "openclaw") -> None:
         self._binary = binary
 
-    def spawn(self, task_id: str, prompt: str, session_label: str = "") -> str:
+    def spawn(
+        self,
+        task_id: str,
+        prompt: str,
+        session_label: str = "",
+        reply_chat_id: str = "",
+    ) -> str:
         """Spawn an OpenClaw agent session.
 
         Returns the session key used to identify this session.
@@ -32,6 +38,13 @@ class OpenClawRunner(AgentRunner):
             "--message",
             prompt,
         ]
+        # If a reply chat is provided, deliver results to Feishu
+        if reply_chat_id:
+            cmd.extend([
+                "--deliver",
+                "--reply-channel", "feishu",
+                "--reply-to", reply_chat_id,
+            ])
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -10,7 +10,10 @@ from tests.memory_store import MemoryBackend
 class _NoopRunner(AgentRunner):
     """Minimal agent runner that always succeeds (for tests that don't care)."""
 
-    def spawn(self, task_id: str, prompt: str, session_label: str = "") -> str:
+    def spawn(
+        self, task_id: str, prompt: str,
+        session_label: str = "", reply_chat_id: str = "",
+    ) -> str:
         return session_label or f"task-{task_id}"
 
     def is_running(self, session_key: str) -> bool:

--- a/tests/test_spawn_rollback.py
+++ b/tests/test_spawn_rollback.py
@@ -16,7 +16,10 @@ class FakeRunner(AgentRunner):
         self._fail = fail
         self.spawned: list[tuple[str, str]] = []
 
-    def spawn(self, task_id: str, prompt: str, session_label: str = "") -> str:
+    def spawn(
+        self, task_id: str, prompt: str,
+        session_label: str = "", reply_chat_id: str = "",
+    ) -> str:
         if self._fail:
             raise RuntimeError("simulated spawn failure")
         session_id = session_label or f"task-{task_id}"


### PR DESCRIPTION
两个问题：

**1. 每步状态变化通知主 session**
之前只在 plan 完成时通知。现在 step_started / step_done / step_failed / spawn_failed / plan_stuck / plan_completed 都会通过 `openclaw system event --mode now` 通知主 session，Luna 可以实时响应和 replan。

**2. Agent 结果发送到 Feishu 群**
`OpenClawRunner.spawn` 新增 `reply_chat_id` 参数，传入 task_chat_id 后会加 `--deliver --reply-channel feishu --reply-to <chat_id>`，agent 完成后结果自动发到对应的 Feishu 临时群。

Ref #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time event-driven notifications for task execution steps (step started, completed, failed, plan updates)
  * Tasks can now be associated with specific reply channels for targeted notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->