### PR TITLE
fix: restore polyline arrows + streaming bridge + plan confirm button

### DIFF
--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -62,6 +62,29 @@ class OpenClawRunner(AgentRunner):
             raise RuntimeError(
                 f"Agent process exited immediately with code {ret} (cmd: {cmd[0]})"
             )
+
+        # Start streaming bridge to push real-time output to Feishu chat
+        if reply_chat_id:
+            bridge_script = os.environ.get(
+                "STREAMING_BRIDGE",
+                str(Path.home() / ".openclaw" / "workspace" / "scripts"
+                    / "streaming-bridge.py"),
+            )
+            if os.path.exists(bridge_script):
+                import contextlib
+
+                with contextlib.suppress(Exception):
+                    subprocess.Popen(
+                        [
+                            "python3", bridge_script,
+                            session_id, reply_chat_id,
+                            "--timeout", "1800",
+                        ],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        start_new_session=True,
+                    )
+
         return session_id
 
     def is_running(self, session_key: str) -> bool:

--- a/src/luna_os/timeline.py
+++ b/src/luna_os/timeline.py
@@ -465,10 +465,21 @@ steps.forEach(s => {{
         }} else {{
             const x1 = from.cx + 2, y1 = from.cy;
             const x2 = to.lx - 2, y2 = to.ly;
-            const midX = (x1 + x2) / 2;
+            // Cross-row: route via polyline through the gap between rows
+            const gapKey = fromRow + '-' + toRow;
+            if (!crossRowArrowIdx[gapKey]) crossRowArrowIdx[gapKey] = 0;
+            const vOffset = crossRowArrowIdx[gapKey] * arrowLineSpacing;
+            crossRowArrowIdx[gapKey]++;
+            // Find the vertical midpoint between the two rows
+            const fromBottom = from.bottom || from.cy + 20;
+            const toTop = to.top || to.cy - 20;
+            const gapMid = (fromBottom + toTop) / 2;
+            const rightEdge = totalW + wrapMargin * 0.7 + vOffset;
+            const leftEdge = wrapMargin * 0.3 + vOffset;
             path.setAttribute('d',
-                `M${{x1}},${{y1}} C${{midX}},${{y1}} `
-                + `${{midX}},${{y2}} ${{x2}},${{y2}}`);
+                `M${{x1}},${{y1}} H${{rightEdge}} `
+                + `V${{gapMid}} H${{leftEdge}} `
+                + `V${{y2}} H${{x2}}`);
         }}
         path.setAttribute('fill', 'none');
         path.setAttribute('stroke', strokeColor);


### PR DESCRIPTION
三个问题修复：

1. **跨行箭头恢复折线** — PR #20 重写 timeline.py 时把跨行箭头从折线（H-V-H-V-H）改成了曲线（C），现在恢复
2. **Streaming bridge** — spawn agent 时同时启动 streaming-bridge.py，临时群里会有实时流式卡片
3. **Plan 确认按钮**（在 lark-oauth-handler.py 中，不在此 repo）— card_action handler 现在处理 plan_confirm/modify/cancel 按钮

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming bridge functionality now automatically activates during agent process initialization when communication identifiers are provided

* **Improvements**
  * Enhanced timeline visualization with improved arrow routing logic for connections between rows, including optimized path calculations and better support for multiple simultaneous arrows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->