### PR TITLE
fix: separate cross-row arrow descent lines

### DIFF
--- a/src/luna_os/timeline.py
+++ b/src/luna_os/timeline.py
@@ -479,9 +479,11 @@ steps.forEach(s => {{
             // Stay close: extend only 20px beyond the rightmost node
             const margin = 20 + vOffset;
             const turnX = Math.max(x1, x2) + margin;
+            // Offset the descent line on the left so multiple arrows don't overlap
+            const descentX = x2 - 6 - vOffset;
             path.setAttribute('d',
                 `M${{x1}},${{y1}} H${{turnX}} `
-                + `V${{gapMid}} H${{x2}} V${{y2}}`);
+                + `V${{gapMid}} H${{descentX}} V${{y2}} H${{x2}}`);
         }}
         path.setAttribute('fill', 'none');
         path.setAttribute('stroke', strokeColor);


### PR DESCRIPTION
左侧竖线段重叠。加 descentX offset 让多条折线分开。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrow rendering in timeline plan steps to prevent visual overlap when multiple arrows are displayed in the same region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->