### PR TITLE
fix: is_running cron-based check + single confirm button

### DIFF
--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -9,19 +9,30 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
+import sys
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from luna_os.agents.base import AgentRunner
 
 logger = logging.getLogger(__name__)
 
+# Default path to streaming-bridge.py
+_DEFAULT_BRIDGE = Path.home() / ".openclaw" / "workspace" / "scripts" / "streaming-bridge.py"
+
 
 class OpenClawRunner(AgentRunner):
     """Spawn agent sessions via OpenClaw Gateway's cron one-shot mechanism."""
 
-    def __init__(self, binary: str = "openclaw") -> None:
+    def __init__(
+        self,
+        binary: str = "openclaw",
+        bridge_script: str | Path | None = None,
+    ) -> None:
         self._binary = binary
+        self._bridge_script = Path(bridge_script) if bridge_script else _DEFAULT_BRIDGE
 
     def spawn(
         self,
@@ -36,7 +47,10 @@ class OpenClawRunner(AgentRunner):
         session. The Gateway manages the session lifecycle, streaming,
         and announces the result back to the main session on completion.
 
-        Returns the cron job ID as the session key.
+        If *reply_chat_id* is provided and a streaming bridge script exists,
+        a background bridge process is started to stream output to the Lark chat.
+
+        Returns the cron job name as the session key.
         """
         name = session_label or f"task-{task_id}"
         # Schedule 5 seconds from now (minimum viable delay)
@@ -88,28 +102,100 @@ class OpenClawRunner(AgentRunner):
             "Spawned isolated session: name=%s job_id=%s at=%s",
             name, job_id, run_at,
         )
+
+        # Start streaming bridge if we have a chat to stream to
+        if reply_chat_id:
+            self._start_bridge(name, reply_chat_id, task_id)
+
         return name
 
-    def is_running(self, session_key: str) -> bool:
-        """Check if a session is still running.
+    def _start_bridge(
+        self, session_label: str, chat_id: str, task_id: str = ""
+    ) -> None:
+        """Launch streaming-bridge.py in the background.
 
-        Checks for the cron job in the job list, or for an active session
-        file in the sessions directory.
+        The bridge watches for a new session file matching *session_label*
+        and streams output to the Lark *chat_id* via CardKit.
         """
-        import os
-        from pathlib import Path
+        if not self._bridge_script.exists():
+            logger.warning(
+                "Streaming bridge not found at %s, skipping", self._bridge_script
+            )
+            return
 
-        # Check session file activity (last modified within 5 minutes)
+        cmd = [
+            sys.executable,
+            str(self._bridge_script),
+            session_label,  # bridge's find_session_file will search for this
+            chat_id,
+            "--timeout", "1800",
+        ]
+        if task_id:
+            cmd.extend(["--task-id", task_id])
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=open("/tmp/streaming-bridge.log", "a"),
+                start_new_session=True,  # detach from parent
+            )
+            logger.info(
+                "Started streaming bridge: pid=%d label=%s chat=%s",
+                proc.pid, session_label, chat_id,
+            )
+        except Exception as exc:
+            logger.warning("Failed to start streaming bridge: %s", exc)
+
+    def is_running(self, session_key: str) -> bool:
+        """Check if a spawned session is still running.
+
+        Uses ``openclaw cron list --json`` to check if the cron job with
+        the matching name still exists. Since jobs are created with
+        ``--delete-after-run``, a job's presence means it's either
+        pending or actively running.
+
+        Falls back to session file check if cron list fails.
+        """
+        try:
+            result = subprocess.run(
+                [self._binary, "cron", "list", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                data = json.loads(result.stdout)
+                jobs = data if isinstance(data, list) else data.get("jobs", [])
+                for job in jobs:
+                    if job.get("name") == session_key and job.get("enabled", False):
+                        state = job.get("state", {})
+                        # Job exists and hasn't errored out
+                        if state.get("lastStatus") not in ("error",):
+                            return True
+                        # Even if last status was error, if it hasn't run yet
+                        # (no lastRunAtMs), it's still pending
+                        if not state.get("lastRunAtMs"):
+                            return True
+        except Exception as exc:
+            logger.debug("cron list check failed, falling back: %s", exc)
+            # Fall back to file check
+            return self._check_session_file(session_key)
+
+        return False
+
+    @staticmethod
+    def _check_session_file(session_key: str) -> bool:
+        """Fallback: check if a session file exists and was recently modified."""
+        import time
+
         sessions_dir = os.environ.get(
             "OPENCLAW_SESSIONS_DIR",
             str(Path.home() / ".openclaw" / "agents" / "main" / "sessions"),
         )
         jsonl_path = Path(sessions_dir) / f"{session_key}.jsonl"
         if jsonl_path.exists():
-            import time
-
             age = time.time() - jsonl_path.stat().st_mtime
             if age < 300:  # Modified within 5 minutes
                 return True
-
         return False

--- a/src/luna_os/timeline.py
+++ b/src/luna_os/timeline.py
@@ -479,8 +479,8 @@ steps.forEach(s => {{
             // Stay close: extend only 20px beyond the rightmost node
             const margin = 20 + vOffset;
             const turnX = Math.max(x1, x2) + margin;
-            // Offset the descent line on the left so multiple arrows don't overlap
-            const descentX = x2 - 6 - vOffset;
+            // Offset the descent line further left to leave room for arrowheads
+            const descentX = x2 - 20 - vOffset;
             path.setAttribute('d',
                 `M${{x1}},${{y1}} H${{turnX}} `
                 + `V${{gapMid}} H${{descentX}} V${{y2}} H${{x2}}`);

--- a/tests/test_confirm_card.py
+++ b/tests/test_confirm_card.py
@@ -23,23 +23,20 @@ class TestBuildConfirmCard:
         card = Planner.build_confirm_card(plan)
         assert card["header"]["title"]["content"].startswith("📋 Plan 确认")
         assert card["header"]["template"] == "blue"
-        # Must have action element with 3 buttons
+        # Must have action element with 1 confirm button
         actions = [e for e in card["elements"] if e.get("tag") == "action"]
         assert len(actions) == 1
         buttons = actions[0]["actions"]
-        assert len(buttons) == 3
-        # Verify button action values
+        assert len(buttons) == 1
         assert buttons[0]["value"]["action"] == "plan_confirm"
-        assert buttons[1]["value"]["action"] == "plan_modify"
-        assert buttons[2]["value"]["action"] == "plan_cancel"
 
     def test_plan_id_and_chat_id_in_buttons(self):
         plan = _make_plan()
         card = Planner.build_confirm_card(plan)
         actions = [e for e in card["elements"] if e.get("tag") == "action"]
-        for btn in actions[0]["actions"]:
-            assert btn["value"]["chat_id"] == "oc_test"
-            assert btn["value"]["plan_id"] == "p1"
+        btn = actions[0]["actions"][0]
+        assert btn["value"]["chat_id"] == "oc_test"
+        assert btn["value"]["plan_id"] == "p1"
 
     def test_steps_displayed(self):
         plan = _make_plan(n_steps=5)


### PR DESCRIPTION
## Changes

### 1. Fix is_running false negatives (root cause of auto-fail)
Gateway creates isolated sessions with UUID filenames, not session labels. The old file-based check (`task-xxx.jsonl`) always returned False → check-contracts auto-failed tasks after 2 minutes even when they completed successfully.

Now uses `openclaw cron list --json` to check if the cron job with matching name still exists. Since jobs use `--delete-after-run`, presence = still running.

### 2. Simplify confirm card
Remove modify/cancel buttons, keep only ✅ 确认执行. If Carl wants changes he'll just chat about it.

### Tests
101 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background streaming bridge started for reply-based sessions to enable live reply streaming.
  * Improved chat creation to ensure members are added when needed.

* **Bug Fixes**
  * More reliable job/session status detection using cron listing with a recent-file fallback.
  * Cross-row timeline arrows adjusted for better visual spacing.

* **Chores**
  * Confirmation UI simplified to a single confirm action; reporting prompt now mandates explicit step.done/step.failed commands.

* **Tests**
  * Expanded tests for cron-based status checks and confirmation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->