### PR TITLE
fix: increase cron schedule delay from 5s to 15s

### DIFF
--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -53,8 +53,11 @@ class OpenClawRunner(AgentRunner):
         Returns the cron job name as the session key.
         """
         name = session_label or f"task-{task_id}"
-        # Schedule 5 seconds from now (minimum viable delay)
-        run_at = (datetime.now(UTC) + timedelta(seconds=5)).strftime(
+        # Schedule 15 seconds from now — must be enough for the cron add
+        # command itself to complete + Gateway to register the job.
+        # 5s was too tight: large prompts take 2-3s to serialize, and
+        # if createdAtMs > schedule.at the job never fires.
+        run_at = (datetime.now(UTC) + timedelta(seconds=15)).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
 


### PR DESCRIPTION
## Root Cause

When the prompt is large, `subprocess.run` takes 2-3s to serialize and send to the CLI. If `createdAtMs > schedule.at`, the Gateway considers the job's trigger time already passed and **never executes it**.

## Evidence

`task-9f0573ed-retry`:
- `schedule.at = 15:44:00 UTC`
- `createdAtMs = 15:44:23 UTC` (23 seconds late)
- `runningAtMs = None` (never fired)

## Fix

Increase delay from 5s to 15s. This gives enough headroom for large prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of scheduled task execution by adjusting timing parameters for system command registration to ensure proper serialization and initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->