### PR TITLE
refactor: replace cron one-shot with direct openclaw agent spawn

### DIFF
--- a/tests/test_openclaw_runner.py
+++ b/tests/test_openclaw_runner.py
@@ -1,217 +1,130 @@
-"""Tests for OpenClawRunner (isolated session spawning via cron)."""
+"""Tests for OpenClawRunner (isolated session spawning via openclaw agent)."""
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from luna_os.agents.openclaw import OpenClawRunner
 
 
 class TestOpenClawRunnerSpawn:
-    """Test that spawn creates isolated sessions via openclaw cron add."""
+    """Test that spawn creates isolated sessions via openclaw agent."""
 
-    def test_spawn_calls_cron_add(self):
+    def test_spawn_calls_agent(self):
         runner = OpenClawRunner()
-        fake_output = json.dumps({"id": "job-123", "name": "task-t1"})
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=fake_output,
-                stderr="",
-            )
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=12345)
             result = runner.spawn("t1", "do something", "task-label")
 
         assert result == "task-label"
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
         assert cmd[0] == "openclaw"
-        assert cmd[1] == "cron"
-        assert cmd[2] == "add"
-        assert "--session" in cmd
-        assert "isolated" in cmd
-        assert "--announce" in cmd
-        assert "--delete-after-run" in cmd
+        assert cmd[1] == "agent"
+        assert "--session-id" in cmd
+        assert "task-label" in cmd
         assert "--message" in cmd
         assert "do something" in cmd
 
     def test_spawn_with_reply_chat_id(self):
         runner = OpenClawRunner()
-        fake_output = json.dumps({"id": "job-456"})
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=fake_output,
-                stderr="",
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=12345)
+            runner.spawn(
+                "t2", "prompt", "label",
+                reply_chat_id="oc_abc123",
             )
-            runner.spawn("t2", "prompt", "label", reply_chat_id="oc_abc123")
 
-        cmd = mock_run.call_args[0][0]
-        assert "--channel" in cmd
+        cmd = mock_popen.call_args[0][0]
+        assert "--deliver" in cmd
+        assert "--reply-channel" in cmd
         assert "feishu" in cmd
-        assert "--to" in cmd
-        assert "oc_abc123" in cmd
+        assert "--reply-to" in cmd
+        assert "chat:oc_abc123" in cmd
 
     def test_spawn_without_reply_chat_id(self):
         runner = OpenClawRunner()
-        fake_output = json.dumps({"id": "job-789"})
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=fake_output,
-                stderr="",
-            )
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=12345)
             runner.spawn("t3", "prompt", "label")
 
-        cmd = mock_run.call_args[0][0]
-        assert "--channel" not in cmd
-        assert "--to" not in cmd
-
-    def test_spawn_failure_raises(self):
-        runner = OpenClawRunner()
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=1,
-                stdout="",
-                stderr="Error: something went wrong",
-            )
-            with pytest.raises(RuntimeError, match="cron add failed"):
-                runner.spawn("t4", "prompt")
-
-    def test_spawn_bad_json_raises(self):
-        runner = OpenClawRunner()
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout="not json",
-                stderr="",
-            )
-            with pytest.raises(RuntimeError, match="parse cron add output"):
-                runner.spawn("t5", "prompt")
-
-    def test_spawn_empty_job_id_raises(self):
-        runner = OpenClawRunner()
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=json.dumps({"id": ""}),
-                stderr="",
-            )
-            with pytest.raises(RuntimeError, match="empty job id"):
-                runner.spawn("t6", "prompt")
+        cmd = mock_popen.call_args[0][0]
+        assert "--deliver" not in cmd
+        assert "--reply-channel" not in cmd
 
     def test_spawn_default_session_label(self):
         runner = OpenClawRunner()
-        fake_output = json.dumps({"id": "job-abc"})
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=fake_output,
-                stderr="",
-            )
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock(pid=12345)
             result = runner.spawn("my-task-id", "prompt")
 
         assert result == "task-my-task-id"
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_popen.call_args[0][0]
         assert "task-my-task-id" in cmd
 
 
 class TestOpenClawRunnerIsRunning:
-    """Test is_running checks cron job list."""
+    """Test is_running checks for running agent process."""
 
-    @staticmethod
-    def _cron_output(jobs):
-        return json.dumps({"jobs": jobs})
-
-    def test_job_exists_enabled(self):
+    def test_process_running(self):
         runner = OpenClawRunner()
-        out = self._cron_output([
-            {"name": "task-abc", "enabled": True, "state": {"lastStatus": "ok"}},
-        ])
         with patch("subprocess.run") as m:
-            m.return_value = MagicMock(returncode=0, stdout=out, stderr="")
+            m.return_value = MagicMock(
+                returncode=0, stdout="12345\n", stderr="",
+            )
             assert runner.is_running("task-abc") is True
 
-    def test_job_not_found(self):
+    def test_process_not_running_no_file(self, tmp_path):
         runner = OpenClawRunner()
-        out = self._cron_output([
-            {"name": "other-task", "enabled": True, "state": {}},
-        ])
-        with patch("subprocess.run") as m:
-            m.return_value = MagicMock(returncode=0, stdout=out, stderr="")
+        with patch("subprocess.run") as m, \
+             patch.dict(
+                 "os.environ",
+                 {"OPENCLAW_SESSIONS_DIR": str(tmp_path)},
+             ):
+            m.return_value = MagicMock(
+                returncode=1, stdout="", stderr="",
+            )
             assert runner.is_running("task-abc") is False
 
-    def test_job_disabled(self):
-        runner = OpenClawRunner()
-        out = self._cron_output([
-            {"name": "task-abc", "enabled": False, "state": {"lastStatus": "ok"}},
-        ])
-        with patch("subprocess.run") as m:
-            m.return_value = MagicMock(returncode=0, stdout=out, stderr="")
-            assert runner.is_running("task-abc") is False
-
-    def test_job_errored_with_run(self):
-        runner = OpenClawRunner()
-        out = self._cron_output([
-            {
-                "name": "task-abc",
-                "enabled": True,
-                "state": {"lastStatus": "error", "lastRunAtMs": 123},
-            },
-        ])
-        with patch("subprocess.run") as m:
-            m.return_value = MagicMock(returncode=0, stdout=out, stderr="")
-            assert runner.is_running("task-abc") is False
-
-    def test_job_pending_no_run_yet(self):
-        runner = OpenClawRunner()
-        out = self._cron_output([
-            {"name": "task-abc", "enabled": True, "state": {}},
-        ])
-        with patch("subprocess.run") as m:
-            m.return_value = MagicMock(returncode=0, stdout=out, stderr="")
-            assert runner.is_running("task-abc") is True
-
-    def test_cron_list_fails_fallback_to_file(self, tmp_path):
+    def test_process_not_running_recent_file(self, tmp_path):
         runner = OpenClawRunner()
         session_file = tmp_path / "task-abc.jsonl"
         session_file.write_text('{"type":"message"}\n')
 
         with patch("subprocess.run") as m, \
-             patch.dict("os.environ", {"OPENCLAW_SESSIONS_DIR": str(tmp_path)}):
-            m.side_effect = Exception("cron list failed")
+             patch.dict(
+                 "os.environ",
+                 {"OPENCLAW_SESSIONS_DIR": str(tmp_path)},
+             ):
+            m.return_value = MagicMock(
+                returncode=1, stdout="", stderr="",
+            )
             assert runner.is_running("task-abc") is True
 
-    def test_cron_list_fails_no_file(self, tmp_path):
+    def test_pgrep_fails_fallback_to_file(self, tmp_path):
+        runner = OpenClawRunner()
+        session_file = tmp_path / "task-abc.jsonl"
+        session_file.write_text('{"type":"message"}\n')
+
+        with patch("subprocess.run") as m, \
+             patch.dict(
+                 "os.environ",
+                 {"OPENCLAW_SESSIONS_DIR": str(tmp_path)},
+             ):
+            m.side_effect = Exception("pgrep failed")
+            assert runner.is_running("task-abc") is True
+
+    def test_pgrep_fails_no_file(self, tmp_path):
         runner = OpenClawRunner()
 
         with patch("subprocess.run") as m, \
-             patch.dict("os.environ", {"OPENCLAW_SESSIONS_DIR": str(tmp_path)}):
-            m.side_effect = Exception("cron list failed")
+             patch.dict(
+                 "os.environ",
+                 {"OPENCLAW_SESSIONS_DIR": str(tmp_path)},
+             ):
+            m.side_effect = Exception("pgrep failed")
             assert runner.is_running("task-abc") is False
-
-    def test_empty_job_list(self):
-        runner = OpenClawRunner()
-        out = self._cron_output([])
-        with patch("subprocess.run") as m:
-            m.return_value = MagicMock(returncode=0, stdout=out, stderr="")
-            assert runner.is_running("task-abc") is False
-
-    def test_cron_list_returns_plain_list(self):
-        """Handle case where cron list returns a plain array instead of {jobs:[]}."""
-        runner = OpenClawRunner()
-        out = json.dumps([
-            {"name": "task-abc", "enabled": True, "state": {"lastStatus": "ok"}},
-        ])
-        with patch("subprocess.run") as m:
-            m.return_value = MagicMock(returncode=0, stdout=out, stderr="")
-            assert runner.is_running("task-abc") is True


### PR DESCRIPTION
## Why

The cron-based spawn had a fundamental timing bug: if `createdAtMs > schedule.at`, the job never fires. This caused tasks to be created but never executed (e.g. task-9f0573ed-retry).

PR #35 increased the delay from 5s to 15s as a band-aid, but the real fix is to not use cron at all.

## What Changed

- `spawn()`: `openclaw cron add --at +15s` → `openclaw agent --session-id` (Popen, non-blocking)
- `is_running()`: cron list check → pgrep + session file fallback
- No more timing window, no more 15-second delay
- Streaming bridge starts before agent (was after)
- -128 lines of cron-specific code

## Tests

94 tests pass, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live streaming support for agent execution with real-time delivery notifications.

* **Bug Fixes**
  * Improved agent process detection and session lifecycle tracking.

* **Refactor**
  * Modernized agent execution architecture for enhanced reliability and persistent logging.

* **Tests**
  * Comprehensive test updates for agent-based execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->