### PR TITLE
fix: remove 2-min process-dead auto-fail (false positive)

### DIFF
--- a/src/luna_os/planner.py
+++ b/src/luna_os/planner.py
@@ -1359,30 +1359,6 @@ Report results to: {chat_id}
                     fail_reason = (
                         f"Auto-failed: step stuck for {age_min:.0f} minutes (timeout=45min)"
                     )
-                elif age_min > 2 and self.agent_runner:
-                    task_id = step.task_id or ""
-                    task_obj = self.store.get_task(task_id) if task_id else None
-                    session_key = task_obj.session_key if task_obj else ""
-
-                    # Fast path: if session_key is still the placeholder after
-                    # 2+ minutes, spawn never succeeded.
-                    if session_key == "cron-pending":
-                        should_fail = True
-                        fail_reason = (
-                            f"Auto-failed: spawn never completed "
-                            f"(session_key still cron-pending after {age_min:.0f} min)"
-                        )
-                    else:
-                        # Normal path: check if the agent process is alive
-                        task_chat = task_obj.task_chat_id if task_obj else ""
-                        check_key = session_key or (
-                            f"task-{task_chat[-8:]}" if task_chat else ""
-                        )
-                        if check_key and not self.agent_runner.is_running(check_key):
-                            should_fail = True
-                            fail_reason = (
-                                f"Auto-failed: agent process dead after {age_min:.0f} minutes"
-                            )
 
                 if should_fail:
                     existing = self.store.get_step(full.id, step.step_num)


### PR DESCRIPTION
## Bug

Steps falsely marked as `Auto-failed: agent process dead after N minutes` while the agent is still running inside the Gateway.

## Root Cause

`openclaw agent` is an HTTP request to the Gateway. The agent runs inside the Gateway's Node.js process, not as a separate OS process. `pgrep` can't find it → `is_running()` returns false → check-contracts marks the step as failed.

## Fix

Remove the 2-minute process-dead check. Keep only the 45-minute timeout. Spawn failures are caught immediately by Popen exceptions (PR #36).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified stuck step detection logic by removing the 2-minute spawn failure check. The system now relies solely on the 45-minute timeout threshold.

* **Tests**
  * Removed test cases for 2-minute spawn failure detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->