### PR TITLE
fix: subagent streaming text + session cost resolution

### DIFF
--- a/src/luna_os/planner.py
+++ b/src/luna_os/planner.py
@@ -579,6 +579,14 @@ Report progress at each key milestone.
 ## Task ID
 {task_id}
 
+## Progress Updates (IMPORTANT)
+**Output text between tool calls** to show your progress. Do NOT just
+think and call tools silently — write a brief text message after each
+key action so the streaming card shows what you are doing. Example:
+- "Found 9592 primes, now computing the sum..."
+- "Matrix multiplication done, computing eigenvalues..."
+This makes your work visible in real-time.
+
 ## Reporting (REQUIRED - session FAILS without this)
 
 **You MUST call one of these as your FINAL action.**


### PR DESCRIPTION
## Problem
Subagent streaming cards showed only tool status bar, no text content until final message. Cost extraction failed for Gateway RPC sessions (colon-separated keys).

## Root Cause
1. Subagent prompt didn't instruct agent to output text between tool calls. Default behavior: think → tool → think → tool → final text.
2. `_extract_session_cost` expected session key as filename, but Gateway RPC uses `agent:main:subagent:xxx` keys with UUID filenames.

## Fix
1. Added 'Progress Updates' section to spawn prompt requiring text output between tool calls
2. `_extract_session_cost` now resolves Gateway session keys via `openclaw sessions --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Real-time progress updates now displayed during planning operations, providing visibility into ongoing work and intermediate results
- Session cost extraction improved with enhanced file resolution capabilities and automatic fallback mechanisms for more reliable tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->