### PR TITLE
refactor: move check-waiting-todos into luna-os

### DIFF
--- a/src/luna_os/check_waiting_todos.py
+++ b/src/luna_os/check_waiting_todos.py
@@ -1,0 +1,82 @@
+"""Check waiting tasks with Lark todo integration.
+
+Polls the task store for tasks in 'waiting' state with wait_type='todo'.
+If the corresponding Lark todo is completed, auto-responds the task.
+
+Intended to run via cron every 2 minutes:
+    luna-os check-waiting-todos
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def check_waiting_todos() -> dict[str, int]:
+    """Check all waiting todo tasks and respond completed ones.
+
+    Returns dict with 'checked' and 'responded' counts.
+    """
+    try:
+        from lark_toolkit import LarkClient
+        from lark_toolkit.todo import get_task as get_lark_task
+    except ImportError:
+        logger.warning("lark-toolkit not installed, skipping todo check")
+        return {"checked": 0, "responded": 0, "error": "lark-toolkit not installed"}
+
+    from luna_os.store.postgres import PostgresBackend
+
+    store = PostgresBackend()
+    waiting = store.waiting_tasks()
+    if not waiting:
+        return {"checked": 0, "responded": 0}
+
+    client = LarkClient()
+    checked = 0
+    responded = 0
+
+    for task in waiting:
+        if task.get("wait_type") != "todo":
+            continue
+        todo_id = task.get("wait_todo_id")
+        if not todo_id:
+            continue
+
+        checked += 1
+        try:
+            todo = get_lark_task(client, todo_id, token=client.get_user_token())
+            task_data = todo.get("task", todo)
+            completed_at = task_data.get("completed_at")
+
+            if completed_at and completed_at != "0":
+                task_id = task["id"]
+                logger.info("Task %s todo completed, responding...", task_id)
+                result = subprocess.run(
+                    [
+                        sys.executable, "-m", "luna_os.cli",
+                        "task", "respond", task_id, "用户已完成待办",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if result.returncode == 0:
+                    responded += 1
+                    logger.info("Task %s responded OK", task_id)
+                else:
+                    logger.error(
+                        "Task %s respond failed: %s",
+                        task_id,
+                        result.stderr[:200],
+                    )
+        except Exception:
+            logger.exception("Task %s check failed", task.get("id", "?"))
+
+    if checked:
+        logger.info("Checked %d todos, responded %d", checked, responded)
+
+    return {"checked": checked, "responded": responded}

--- a/src/luna_os/cli.py
+++ b/src/luna_os/cli.py
@@ -36,6 +36,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from datetime import datetime
 from decimal import Decimal
@@ -331,6 +332,15 @@ def main() -> None:
         task_cli(rest)
     elif top == "plan":
         plan_cli(rest)
+    elif top == "check-waiting-todos":
+        from luna_os.check_waiting_todos import check_waiting_todos
+
+        logging.basicConfig(
+            level=logging.INFO,
+            format="[check-todos] %(message)s",
+        )
+        result = check_waiting_todos()
+        print_json(result)
     else:
         print(f"Unknown command: {top}", file=sys.stderr)
         print(__doc__)


### PR DESCRIPTION
Move check-waiting-todos logic from workspace scripts/ into `luna_os.check_waiting_todos`. CLI: `luna-os check-waiting-todos`. Workspace script replaced with shim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI command to automatically check and respond to waiting todo items
  * System now auto-responds when integrated todo tasks reach completion status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->