### PR TITLE
refactor: move streaming-bridge + session-overview into luna-os

### DIFF
--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -20,11 +20,6 @@ from luna_os.agents.base import AgentRunner
 
 logger = logging.getLogger(__name__)
 
-# Default path to streaming-bridge.py
-_DEFAULT_BRIDGE = (
-    Path.home() / ".openclaw" / "workspace" / "scripts" / "streaming-bridge.py"
-)
-
 
 class OpenClawRunner(AgentRunner):
     """Spawn subagent sessions via Gateway RPC (``openclaw gateway call agent``)."""
@@ -32,10 +27,8 @@ class OpenClawRunner(AgentRunner):
     def __init__(
         self,
         binary: str = "openclaw",
-        bridge_script: str | Path | None = None,
     ) -> None:
         self._binary = binary
-        self._bridge_script = Path(bridge_script) if bridge_script else _DEFAULT_BRIDGE
 
     def spawn(
         self,
@@ -96,17 +89,10 @@ class OpenClawRunner(AgentRunner):
     def _start_bridge(
         self, session_label: str, chat_id: str, task_id: str = "",
     ) -> None:
-        """Launch streaming-bridge.py in the background."""
-        if not self._bridge_script.exists():
-            logger.warning(
-                "Streaming bridge not found at %s, skipping",
-                self._bridge_script,
-            )
-            return
-
+        """Launch streaming bridge in the background."""
         cmd = [
-            sys.executable,
-            str(self._bridge_script),
+            sys.executable, "-m", "luna_os.cli",
+            "streaming-bridge",
             session_label,
             chat_id,
             "--timeout", "1800",

--- a/src/luna_os/cli.py
+++ b/src/luna_os/cli.py
@@ -341,6 +341,14 @@ def main() -> None:
         )
         result = check_waiting_todos()
         print_json(result)
+    elif top == "streaming-bridge":
+        from luna_os.streaming_bridge import main as bridge_main
+
+        bridge_main()
+    elif top == "session-overview":
+        from luna_os.session_overview import main as overview_main
+
+        overview_main()
     else:
         print(f"Unknown command: {top}", file=sys.stderr)
         print(__doc__)

--- a/src/luna_os/session_overview.py
+++ b/src/luna_os/session_overview.py
@@ -1,0 +1,221 @@
+"""Session overview generator.
+
+Reads OpenClaw session store + Lark chat name cache, generates a concise
+overview of all active chat sessions (excludes subagent sessions).
+
+Usage (CLI):
+    luna-os session-overview [--stdout]
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from datetime import UTC, datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
+
+SGT = timezone(timedelta(hours=8))
+
+SESSIONS_FILE = os.path.expanduser("~/.openclaw/agents/main/sessions/sessions.json")
+SESSIONS_DIR = os.path.expanduser("~/.openclaw/agents/main/sessions")
+CHAT_CACHE = os.path.expanduser("~/.openclaw/workspace/data/lark-chats-cache.json")
+
+
+def _load_chat_names() -> dict[str, str]:
+    """Load chat_id -> name mapping from lark-lookup-chat cache."""
+    mapping: dict[str, str] = {}
+    if os.path.exists(CHAT_CACHE):
+        try:
+            with open(CHAT_CACHE) as f:
+                data = json.load(f)
+            for c in data.get("chats", []):
+                mapping[c["chat_id"]] = c["name"]
+        except Exception:
+            pass
+    return mapping
+
+
+def _load_planners() -> dict[str, dict]:
+    """Load chat_id -> planner info mapping from PostgreSQL."""
+    mapping: dict[str, dict] = {}
+    try:
+        from luna_os.store.postgres import PostgresBackend
+
+        store = PostgresBackend()
+        all_plans_raw = store.list_plans() or []
+        all_plans = [
+            p.to_dict() if hasattr(p, "to_dict") else p for p in all_plans_raw
+        ]
+        now = datetime.now(UTC)
+
+        def _still_relevant(p: dict) -> bool:
+            status = p.get("status", "")
+            if status == "cancelled":
+                return False
+            if status in ("completed", "failed"):
+                created = p.get("created_at")
+                if created and hasattr(created, "timestamp"):
+                    age_h = (now - created).total_seconds() / 3600
+                    if age_h > 24:
+                        return False
+            return True
+
+        plans = sorted(
+            [p for p in all_plans if _still_relevant(p)],
+            key=lambda p: p.get("updated_at") or p.get("created_at") or now,
+            reverse=True,
+        )[:30]
+
+        for p in plans:
+            chat_id = p.get("chat_id")
+            if not chat_id or chat_id in mapping:
+                continue
+            plan_id = p["id"]
+            steps = p.get("steps", [])
+            done = sum(
+                1
+                for s in steps
+                if (s.get("status") if isinstance(s, dict) else getattr(s, "status", None))
+                in ("done", "completed")
+            )
+            total = len(steps)
+            status = p.get("status", "unknown")
+            goal = p.get("goal", "")
+            mapping[chat_id] = {
+                "plan_id": plan_id,
+                "status": status,
+                "goal": goal[:60],
+                "progress": f"{done}/{total}",
+            }
+    except Exception:
+        logger.debug("Failed to load planners", exc_info=True)
+
+    return mapping
+
+
+def _relative_time(ts: float) -> str:
+    """Convert timestamp to relative time string."""
+    diff = time.time() - ts
+    if diff < 60:
+        return "just now"
+    if diff < 3600:
+        return f"{int(diff / 60)}m ago"
+    if diff < 86400:
+        return f"{int(diff / 3600)}h ago"
+    return f"{int(diff / 86400)}d ago"
+
+
+def generate_overview(*, output_file: str | None = None) -> dict:
+    """Generate session overview.
+
+    Returns dict with sessions list and counts.
+    """
+    # Load sessions.json
+    if not os.path.exists(SESSIONS_FILE):
+        return {"sessions": [], "total_count": 0, "chat_count": 0, "subagent_count": 0}
+
+    with open(SESSIONS_FILE) as f:
+        all_sessions = json.load(f)
+
+    chat_names = _load_chat_names()
+    planners = _load_planners()
+
+    chat_sessions = []
+    for key, meta in all_sessions.items():
+        # Skip subagent sessions
+        if "subagent" in key:
+            continue
+
+        # Extract chat_id from key
+        chat_id = ""
+        if key.startswith("feishu:group:") or key.startswith("feishu:dm:"):
+            chat_id = key.split(":", 2)[2]
+
+        # Session name
+        name = chat_names.get(chat_id, chat_id or key)
+
+        # Usage
+        usage = meta.get("usage", {})
+        input_tokens = usage.get("input", 0)
+        output_tokens = usage.get("output", 0)
+        total_tokens = input_tokens + output_tokens
+        context_tokens = meta.get("contextTokens", 128000)
+        usage_pct = round(total_tokens / context_tokens * 100, 1) if context_tokens else 0
+
+        # Timing
+        updated_at = meta.get("updatedAt", 0)
+        if isinstance(updated_at, str):
+            try:
+                updated_at = datetime.fromisoformat(updated_at).timestamp()
+            except Exception:
+                updated_at = 0
+        relative = _relative_time(updated_at) if updated_at else "unknown"
+
+        # Last activity
+        last_msg = meta.get("lastMessage", {})
+        last_activity = ""
+        if isinstance(last_msg, dict):
+            role = last_msg.get("role", "")
+            text = last_msg.get("text", "")[:60]
+            last_activity = f"[{role}] {text}" if text else ""
+
+        # Planner info
+        planner_info = planners.get(chat_id)
+
+        chat_sessions.append({
+            "key": key,
+            "chat_id": chat_id,
+            "name": name,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+            "usage_pct": usage_pct,
+            "updated_at": updated_at,
+            "relative_time": relative,
+            "last_activity": last_activity,
+            "compactions": meta.get("compactionCount", 0),
+            "planner": planner_info,
+        })
+
+    chat_sessions.sort(key=lambda s: s["name"])
+
+    result = {
+        "sessions": chat_sessions,
+        "total_count": len(all_sessions),
+        "chat_count": len(chat_sessions),
+        "subagent_count": len(all_sessions) - len(chat_sessions),
+        "generated_at": datetime.now(SGT).isoformat(),
+    }
+
+    # Save if output_file specified
+    out = output_file or os.path.expanduser(
+        "~/.openclaw/workspace/data/session-overview.json"
+    )
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w") as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+
+    return result
+
+
+def main() -> None:
+    """CLI entry point."""
+    logging.basicConfig(level=logging.INFO, format="[session-overview] %(message)s")
+
+    if len(sys.argv) > 1 and sys.argv[1] in ("--help", "-h", "help"):
+        print(__doc__)
+        sys.exit(0)
+
+    result = generate_overview()
+    if "--stdout" in sys.argv:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(json.dumps({
+            "ok": True,
+            "chat_sessions": len(result["sessions"]),
+            "subagents": result["subagent_count"],
+        }))

--- a/src/luna_os/streaming_bridge.py
+++ b/src/luna_os/streaming_bridge.py
@@ -1,0 +1,342 @@
+"""Streaming bridge — monitor an OpenClaw session and stream output to Lark via CardKit.
+
+Usage (CLI):
+    luna-os streaming-bridge <session_id> <chat_id> [--timeout 900] [--task-id TID]
+
+Creates a streaming card in the Lark chat, monitors the session transcript,
+and updates the card in real-time as the agent produces output.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = 0.8
+MAX_CONTENT_LEN = 3800
+PLACEHOLDERS = ("...", "..", ".", "…")
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (replaces openclaw_config dependency)
+# ---------------------------------------------------------------------------
+
+def _get_sessions_dir() -> Path:
+    env = os.environ.get("OPENCLAW_SESSIONS_DIR")
+    if env:
+        return Path(env)
+    home = os.environ.get("OPENCLAW_HOME", os.path.expanduser("~/.openclaw"))
+    return Path(home) / "agents" / "main" / "sessions"
+
+
+# ---------------------------------------------------------------------------
+# Session file resolution
+# ---------------------------------------------------------------------------
+
+def find_session_file(
+    session_id: str,
+    sessions_dir: Path | None = None,
+    max_wait: int = 60,
+) -> Path | None:
+    """Find the .jsonl transcript file for a session ID.
+
+    Searches by: (1) direct filename match, (2) ``openclaw sessions`` list
+    to resolve session key -> UUID, (3) file content search.
+    Waits up to *max_wait* seconds for the file to appear.
+    """
+    sdir = sessions_dir or _get_sessions_dir()
+    deadline = time.time() + max_wait
+
+    while True:
+        # Method 1: Direct filename match
+        for f in sdir.glob("*.jsonl"):
+            if session_id in f.name:
+                return f
+
+        # Method 2: Resolve via sessions list (key -> sessionId -> file)
+        try:
+            res = subprocess.run(
+                ["openclaw", "sessions", "--active", "10", "--json"],
+                capture_output=True, text=True, timeout=8,
+            )
+            if res.returncode == 0 and res.stdout.strip():
+                data = json.loads(res.stdout)
+                sessions = data if isinstance(data, list) else data.get("sessions", [])
+                for s in sessions:
+                    key = s.get("key", "")
+                    sid = s.get("sessionId", s.get("id", ""))
+                    if session_id in key and sid:
+                        candidate = sdir / f"{sid}.jsonl"
+                        if candidate.exists():
+                            logger.info("Resolved via sessions list: %s -> %s", session_id, sid)
+                            return candidate
+        except Exception:
+            pass
+
+        # Method 3: Content search (first 10 lines, recent files only)
+        now = time.time()
+        for f in sorted(sdir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True):
+            try:
+                if now - f.stat().st_mtime > 120:
+                    break
+                with open(f) as fh:
+                    for _i, line in enumerate(fh):
+                        if _i >= 10:
+                            break
+                        if session_id in line:
+                            logger.info(
+                                "Found in file content: %s -> %s",
+                                session_id, f.name,
+                            )
+                            return f
+            except Exception:
+                continue
+
+        if time.time() >= deadline:
+            logger.warning("Session file not found after %ds, closing", max_wait)
+            return None
+
+        time.sleep(3)
+
+
+# ---------------------------------------------------------------------------
+# Content extraction
+# ---------------------------------------------------------------------------
+
+def extract_content(
+    jsonl_path: str | Path,
+    last_offset: int = 0,
+) -> tuple[list[str], str | None, int, list[dict]]:
+    """Read new lines from the session transcript.
+
+    Returns ``(texts, tool_status, new_offset, usage_entries)``.
+    """
+    texts: list[str] = []
+    tool_status: str | None = None
+    usage_entries: list[dict] = []
+    new_offset = last_offset
+
+    try:
+        with open(jsonl_path, "rb") as f:
+            f.seek(last_offset)
+            raw = f.read()
+            new_offset = f.tell()
+
+        for line in raw.decode("utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+            msg = entry.get("message", entry)
+            role = msg.get("role", "")
+
+            if role == "assistant":
+                # Collect usage data
+                usage = msg.get("usage")
+                if isinstance(usage, dict) and (usage.get("input") or usage.get("output")):
+                    cost_obj = usage.get("cost", {})
+                    usage_entries.append({
+                        "input": usage.get("input", 0),
+                        "output": usage.get("output", 0),
+                        "cost": cost_obj.get("total", 0) if isinstance(cost_obj, dict) else 0,
+                    })
+
+                c = msg.get("content", "")
+                if isinstance(c, str) and c.strip():
+                    t = c.strip()
+                    if t not in PLACEHOLDERS:
+                        texts.append(t)
+                elif isinstance(c, list):
+                    for block in c:
+                        if not isinstance(block, dict):
+                            continue
+                        bt = block.get("type", "")
+                        if bt == "text" and block.get("text", "").strip():
+                            t = block["text"].strip()
+                            if t not in PLACEHOLDERS:
+                                texts.append(t)
+                        elif bt == "thinking":
+                            thought = block.get("thinking", "")
+                            if isinstance(thought, str) and thought.strip():
+                                preview = thought.strip()[:80].replace("\n", " ")
+                                tool_status = f"\U0001f4ad {preview}..."
+                        elif bt in ("tool_use", "toolCall"):
+                            name = block.get("name") or block.get("toolName") or "tool"
+                            inp = block.get("input", {})
+                            detail = ""
+                            if isinstance(inp, dict):
+                                for key in ("command", "url", "query", "file_path", "path"):
+                                    if key in inp:
+                                        detail = str(inp[key])[:60]
+                                        break
+                            tool_status = (
+                                f"\U0001f527 {name}: `{detail}`"
+                                if detail
+                                else f"\U0001f527 {name}"
+                            )
+
+            elif role == "toolResult":
+                c = msg.get("content", "")
+                rt = ""
+                if isinstance(c, str):
+                    rt = c.strip()
+                elif isinstance(c, list):
+                    for block in c:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            rt = block.get("text", "").strip()
+                            break
+                if rt:
+                    if len(rt) > 80:
+                        rt = rt[:80] + "..."
+                    tool_status = f"\u2705 {rt}"
+
+    except Exception:
+        logger.debug("Error reading %s", jsonl_path, exc_info=True)
+
+    return texts, tool_status, new_offset, usage_entries
+
+
+# ---------------------------------------------------------------------------
+# Gateway idle check
+# ---------------------------------------------------------------------------
+
+def _is_session_idle(session_id: str) -> bool:
+    """Check if a session is no longer active via openclaw sessions."""
+    try:
+        res = subprocess.run(
+            ["openclaw", "sessions", "--active", "2", "--json"],
+            capture_output=True, text=True, timeout=8,
+        )
+        if res.returncode != 0:
+            return False
+        data = json.loads(res.stdout)
+        sessions = data if isinstance(data, list) else data.get("sessions", [])
+        for s in sessions:
+            key = s.get("key", "")
+            if session_id in key:
+                return False
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main bridge loop
+# ---------------------------------------------------------------------------
+
+def run_bridge(
+    session_id: str,
+    chat_id: str,
+    timeout: int = 900,
+    *,
+    task_id: str = "",
+) -> None:
+    """Run the streaming bridge for a session."""
+    try:
+        from lark_toolkit import LarkClient
+        from lark_toolkit.cards import StreamingCard
+    except ImportError:
+        logger.error("lark-toolkit not installed, cannot run streaming bridge")
+        return
+
+    client = LarkClient()
+    sessions_dir = _get_sessions_dir()
+
+    logger.info("Starting bridge: session=%s chat=%s timeout=%d", session_id, chat_id, timeout)
+
+    # Create streaming card
+    card = StreamingCard(client, chat_id)
+    card.create()
+
+    session_file: Path | None = None
+    last_offset = 0
+    accumulated: list[str] = []
+    all_usage: list[dict] = []
+    idle_count = 0
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        # Find session file if not yet found
+        if session_file is None:
+            session_file = find_session_file(session_id, sessions_dir, max_wait=0)
+            if session_file is None:
+                idle_count += 1
+                if idle_count > 60:  # 60 * 0.8s = 48s no file
+                    logger.warning("Session file not found after 48s, closing")
+                    break
+                time.sleep(UPDATE_INTERVAL)
+                continue
+
+        # Read new content
+        if session_file.exists():
+            texts, tool_status, new_offset, usage = extract_content(
+                session_file, last_offset,
+            )
+            all_usage.extend(usage)
+
+            if texts or tool_status:
+                last_offset = new_offset
+                logger.info("Read %d texts, offset->%d", len(texts), new_offset)
+
+                if texts:
+                    accumulated.extend(texts)
+                    full_text = "\n\n".join(accumulated)
+                    if len(full_text) > MAX_CONTENT_LEN:
+                        full_text = full_text[-MAX_CONTENT_LEN:]
+                    ok = card.update(full_text)
+                    logger.info("Card update: ok=%s len=%d", ok, len(full_text))
+
+                if tool_status:
+                    card.update_status(tool_status)
+                    logger.info("Status: %s", tool_status[:60])
+            else:
+                idle_count += 1
+                if idle_count >= 12 and idle_count % 12 == 0 and _is_session_idle(session_id):
+                    # Final read
+                    if session_file.exists():
+                        texts2, _ts, new_offset2, final_usage = extract_content(
+                            session_file, last_offset,
+                        )
+                        all_usage.extend(final_usage)
+                        if texts2:
+                            accumulated.extend(texts2)
+                            last_offset = new_offset2
+                    logger.info("Session %s confirmed idle by gateway", session_id)
+                    break
+        else:
+            idle_count += 1
+
+        time.sleep(UPDATE_INTERVAL)
+
+    # Close card with final content
+    final = "\n\n".join(accumulated) if accumulated else "\u2705 \u5b8c\u6210"
+    card.close(final)
+    logger.info("Bridge finished")
+
+
+def main() -> None:
+    """CLI entry point for streaming-bridge."""
+    import argparse
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[streaming-bridge] %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(description="Streaming bridge")
+    parser.add_argument("session_id")
+    parser.add_argument("chat_id")
+    parser.add_argument("--task-id", default="")
+    parser.add_argument("--timeout", type=int, default=900)
+    args = parser.parse_args()
+    run_bridge(args.session_id, args.chat_id, args.timeout, task_id=args.task_id)


### PR DESCRIPTION
Move streaming_bridge.py and session_overview.py from workspace scripts/ into luna_os package.

CLI: `luna-os streaming-bridge` / `luna-os session-overview`

Also removes bridge_script parameter from OpenClawRunner — bridge is now launched via `python -m luna_os.cli streaming-bridge` directly, no external script dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming bridge functionality to automatically stream OpenClaw sessions to Lark chat with real-time status updates.
  * Introduced session overview feature displaying all active chat sessions with usage statistics, timing metadata, and planner progress information.
  * Added new CLI commands for accessing streaming bridge and session overview capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->