### PR TITLE
feat: per-step timeout estimation and enforcement

### DIFF
--- a/src/luna_os/agents/base.py
+++ b/src/luna_os/agents/base.py
@@ -15,6 +15,7 @@ class AgentRunner(ABC):
         prompt: str,
         session_label: str = "",
         reply_chat_id: str = "",
+        timeout_minutes: int | None = None,
     ) -> str:
         """Spawn an agent session. Return a session key / identifier."""
 

--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -36,6 +36,7 @@ class OpenClawRunner(AgentRunner):
         prompt: str,
         session_label: str = "",
         reply_chat_id: str = "",
+        timeout_minutes: int | None = None,
     ) -> str:
         """Spawn a subagent session via Gateway RPC.
 
@@ -48,13 +49,15 @@ class OpenClawRunner(AgentRunner):
         child_id = session_label or f"task-{task_id}"
         session_key = f"agent:main:subagent:{child_id}"
 
+        timeout_sec = (timeout_minutes or 30) * 60
+
         params = {
             "message": prompt,
             "sessionKey": session_key,
             "idempotencyKey": str(uuid.uuid4()),
             "deliver": False,
             "lane": "subagent",
-            "timeout": 1800,
+            "timeout": timeout_sec,
         }
 
         cmd = [
@@ -62,7 +65,7 @@ class OpenClawRunner(AgentRunner):
             "--params", json.dumps(params),
             "--expect-final",
             "--json",
-            "--timeout", "1810000",  # slightly over agent timeout
+            "--timeout", str(timeout_sec + 10000),  # slightly over agent timeout
         ]
 
         # Start streaming bridge BEFORE launching agent

--- a/src/luna_os/planner.py
+++ b/src/luna_os/planner.py
@@ -533,6 +533,32 @@ class Planner:
 
     # -- Spawn helpers ---------------------------------------------------------
 
+    @staticmethod
+    def _estimate_timeout(step: Step) -> int:
+        """Estimate timeout in minutes for a step based on its prompt.
+
+        Returns the step's explicit timeout_minutes if set, otherwise
+        estimates based on prompt keywords.
+        """
+        if step.timeout_minutes:
+            return step.timeout_minutes
+
+        prompt = (step.prompt or step.title or "").lower()
+        # Heavy tasks: research, refactor, multi-file, reverse-engineer
+        heavy = ("refactor", "reverse", "rewrite", "migrate", "redesign",
+                 "analyze", "research", "investigate", "audit", "review")
+        if any(kw in prompt for kw in heavy):
+            return 30
+
+        # Medium tasks: write code, implement, test, fix bug
+        medium = ("implement", "write", "create", "build", "fix",
+                  "test", "debug", "integrate", "deploy")
+        if any(kw in prompt for kw in medium):
+            return 15
+
+        # Light tasks: compute, calculate, query, summarize, report
+        return 5
+
     def _build_spawn_prompt(self, plan: Plan, step: Step, task_chat_id: str = "") -> str:
         """Build the prompt for spawning a subagent for a step."""
         prompt_text = step.prompt or step.title or ""
@@ -540,6 +566,7 @@ class Planner:
         chat_id = plan.chat_id or ""
         step_num = step.step_num
         task_id = step.task_id or ""
+        timeout_min = self._estimate_timeout(step)
         ws = os.environ.get(
             "OPENCLAW_WORKSPACE", "/home/ubuntu/.openclaw/workspace"
         )
@@ -609,6 +636,10 @@ cd {ws} && python3 scripts/emit_event.py step.waiting \\
   --task-id {task_id} --result "your question"
 ```
 {task_chat_section}
+## Time Budget
+You have **{timeout_min} minutes** for this step. Plan your approach accordingly.
+If running out of time, emit step.waiting with a progress summary.
+
 ## Parent Chat
 Report results to: {chat_id}
 
@@ -666,11 +697,13 @@ Report results to: {chat_id}
                 updated_step = self.store.get_step(plan.id, step.step_num)
                 if plan_fresh and updated_step:
                     prompt = self._build_spawn_prompt(plan_fresh, updated_step, task_chat_id)
+                    timeout_min = self._estimate_timeout(updated_step)
                     try:
                         session_label = f"task-{task_chat_id[-8:]}" if task_chat_id else ""
                         session_key = self.agent_runner.spawn(
                             task_id, prompt, session_label,
                             reply_chat_id=task_chat_id,
+                            timeout_minutes=timeout_min,
                         )
                         # Update session_key from placeholder to actual value
                         # (use update_task to avoid resetting started_at)
@@ -1024,7 +1057,10 @@ Report results to: {chat_id}
                 deps = list(auto_deps)
             else:
                 deps = []
-            self.store.insert_step(plan.id, step_num, ns["title"], ns["prompt"], deps)
+            self.store.insert_step(
+                plan.id, step_num, ns["title"], ns["prompt"], deps,
+                timeout_minutes=ns.get("timeout_minutes"),
+            )
 
         # Auto-advance if plan is active
         spawn_ok = False
@@ -1362,10 +1398,12 @@ Report results to: {chat_id}
                 should_fail = False
                 fail_reason = ""
 
-                if age_min > 45:
+                step_timeout = step.timeout_minutes or 45
+                if age_min > step_timeout:
                     should_fail = True
                     fail_reason = (
-                        f"Auto-failed: step stuck for {age_min:.0f} minutes (timeout=45min)"
+                        f"Auto-failed: step stuck for {age_min:.0f}min"
+                        f" (timeout={step_timeout}min)"
                     )
 
                 if should_fail:

--- a/src/luna_os/store/base.py
+++ b/src/luna_os/store/base.py
@@ -173,6 +173,7 @@ class StorageBackend(ABC):
         title: str,
         prompt: str,
         depends_on: list[int] | None = None,
+        timeout_minutes: int | None = None,
     ) -> None:
         """Insert a single pending step."""
 

--- a/src/luna_os/store/postgres.py
+++ b/src/luna_os/store/postgres.py
@@ -367,9 +367,15 @@ class PostgresBackend(StorageBackend):
             raw_deps = s.get("depends_on") or []
             deps = [d + 1 for d in raw_deps if d + 1 != i]  # filter self-refs
             self._execute(
-                """INSERT INTO plan_steps (plan_id, step_num, title, prompt, status, depends_on)
-                   VALUES (%s, %s, %s, %s, 'pending', %s)""",
-                (plan_id, i, s.get("title", ""), s.get("prompt", ""), deps),
+                """INSERT INTO plan_steps
+                   (plan_id, step_num, title, prompt, status,
+                    depends_on, timeout_minutes)
+                   VALUES (%s, %s, %s, %s, 'pending', %s, %s)""",
+                (
+                    plan_id, i, s.get("title", ""),
+                    s.get("prompt", ""), deps,
+                    s.get("timeout_minutes"),
+                ),
             )
         return self.get_plan(plan_id)  # type: ignore[return-value]
 
@@ -587,13 +593,16 @@ class PostgresBackend(StorageBackend):
         title: str,
         prompt: str,
         depends_on: list[int] | None = None,
+        timeout_minutes: int | None = None,
     ) -> None:
         # Filter out self-referencing dependencies
         clean_deps = [d for d in (depends_on or []) if d != step_num]
         self._execute(
-            """INSERT INTO plan_steps (plan_id, step_num, title, prompt, status, depends_on)
-               VALUES (%s, %s, %s, %s, 'pending', %s)""",
-            (plan_id, step_num, title, prompt, clean_deps),
+            """INSERT INTO plan_steps
+               (plan_id, step_num, title, prompt, status,
+                depends_on, timeout_minutes)
+               VALUES (%s, %s, %s, %s, 'pending', %s, %s)""",
+            (plan_id, step_num, title, prompt, clean_deps, timeout_minutes),
         )
 
     # -- Events ----------------------------------------------------------------

--- a/src/luna_os/types.py
+++ b/src/luna_os/types.py
@@ -133,6 +133,7 @@ class Step:
     task_id: str | None = None
     result: str | None = None
     depends_on: list[int] = field(default_factory=list)
+    timeout_minutes: int | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
 

--- a/tests/memory_store.py
+++ b/tests/memory_store.py
@@ -215,6 +215,7 @@ class MemoryBackend(StorageBackend):
                     prompt=s.get("prompt", ""),
                     status=StepStatus.PENDING,
                     depends_on=deps,
+                    timeout_minutes=s.get("timeout_minutes"),
                 )
             )
         plan = Plan(
@@ -353,6 +354,7 @@ class MemoryBackend(StorageBackend):
         title: str,
         prompt: str,
         depends_on: list[int] | None = None,
+        timeout_minutes: int | None = None,
     ) -> None:
         plan = self._plans.get(plan_id)
         if plan:
@@ -364,6 +366,7 @@ class MemoryBackend(StorageBackend):
                     prompt=prompt,
                     status=StepStatus.PENDING,
                     depends_on=depends_on or [],
+                    timeout_minutes=timeout_minutes,
                 )
             )
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -13,6 +13,7 @@ class _NoopRunner(AgentRunner):
     def spawn(
         self, task_id: str, prompt: str,
         session_label: str = "", reply_chat_id: str = "",
+        timeout_minutes: int | None = None,
     ) -> str:
         return session_label or f"task-{task_id}"
 

--- a/tests/test_spawn_rollback.py
+++ b/tests/test_spawn_rollback.py
@@ -17,6 +17,7 @@ class FakeRunner(AgentRunner):
     def spawn(
         self, task_id: str, prompt: str,
         session_label: str = "", reply_chat_id: str = "",
+        timeout_minutes: int | None = None,
     ) -> str:
         if self._fail:
             raise RuntimeError("simulated spawn failure")


### PR DESCRIPTION
每个步骤根据 prompt 内容自动预估超时时间，不再一刀切 45 分钟。

- Light (compute/query): 5 min
- Medium (implement/write): 15 min  
- Heavy (refactor/research): 30 min
- 用户可在 step 定义里手动指定 `timeout_minutes`
- Agent 的 spawn prompt 里会告知时间预算
- Auto-fail 使用 per-step timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable timeout parameters for spawned task execution.
  * Automatic timeout estimation based on task complexity classification (heavy, medium, light).
  * Time budget information now displayed in task execution prompts to guide execution planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->