### PR TITLE
feat: per-step model + full plan context in spawn prompt

### DIFF
--- a/src/luna_os/agents/base.py
+++ b/src/luna_os/agents/base.py
@@ -16,6 +16,7 @@ class AgentRunner(ABC):
         session_label: str = "",
         reply_chat_id: str = "",
         timeout_minutes: int | None = None,
+        model: str | None = None,
     ) -> str:
         """Spawn an agent session. Return a session key / identifier."""
 

--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -37,6 +37,7 @@ class OpenClawRunner(AgentRunner):
         session_label: str = "",
         reply_chat_id: str = "",
         timeout_minutes: int | None = None,
+        model: str | None = None,
     ) -> str:
         """Spawn a subagent session via Gateway RPC.
 
@@ -51,7 +52,7 @@ class OpenClawRunner(AgentRunner):
 
         timeout_sec = (timeout_minutes or 30) * 60
 
-        params = {
+        params: dict[str, object] = {
             "message": prompt,
             "sessionKey": session_key,
             "idempotencyKey": str(uuid.uuid4()),
@@ -59,6 +60,8 @@ class OpenClawRunner(AgentRunner):
             "lane": "subagent",
             "timeout": timeout_sec,
         }
+        if model:
+            params["model"] = model
 
         cmd = [
             self._binary, "gateway", "call", "agent",

--- a/src/luna_os/planner.py
+++ b/src/luna_os/planner.py
@@ -571,17 +571,21 @@ class Planner:
             "OPENCLAW_WORKSPACE", "/home/ubuntu/.openclaw/workspace"
         )
 
-        completed = [
-            s
-            for s in plan.steps
-            if (s.status.value if hasattr(s.status, "value") else str(s.status)) == "done"
-        ]
-        context_lines = []
-        for cs in completed[-3:]:
-            context_lines.append(
-                f"- Step {cs.step_num}: {cs.title} -> {_short_desc(cs.result or '', 80)}"
-            )
-        context = "\n".join(context_lines) if context_lines else "(none)"
+        # Build full plan overview so the agent knows the big picture
+        plan_lines = []
+        for s in plan.steps:
+            st = s.status.value if hasattr(s.status, "value") else str(s.status)
+            marker = "→" if s.step_num == step_num else " "
+            deps = f" (after {','.join(str(d) for d in s.depends_on)})" if s.depends_on else ""
+            if st == "done":
+                result = _short_desc(s.result or "", 60)
+                plan_lines.append(f"  {marker} [{st}] {s.step_num}. {s.title}{deps} — {result}")
+            elif st == "running":
+                note = "← YOU" if s.step_num == step_num else "(parallel)"
+                plan_lines.append(f"  {marker} [{st}] {s.step_num}. {s.title}{deps} {note}")
+            else:
+                plan_lines.append(f"  {marker} [{st}] {s.step_num}. {s.title}{deps}")
+        plan_overview = "\n".join(plan_lines)
 
         task_chat_section = ""
         if task_chat_id:
@@ -596,12 +600,15 @@ Report progress at each key milestone.
 ## Plan Goal
 {goal}
 
+## Full Plan Overview
+{plan_overview}
+
+**Your job is ONLY step {step_num}.** Do not duplicate work from other steps.
+If another step is running in parallel, trust that it will handle its own scope.
+
 ## Current Step
 **Step {step_num}: {step.title or ""}**
 {prompt_text}
-
-## Context from Completed Steps
-{context}
 
 ## Task ID
 {task_id}
@@ -698,12 +705,14 @@ Report results to: {chat_id}
                 if plan_fresh and updated_step:
                     prompt = self._build_spawn_prompt(plan_fresh, updated_step, task_chat_id)
                     timeout_min = self._estimate_timeout(updated_step)
+                    step_model = updated_step.model
                     try:
                         session_label = f"task-{task_chat_id[-8:]}" if task_chat_id else ""
                         session_key = self.agent_runner.spawn(
                             task_id, prompt, session_label,
                             reply_chat_id=task_chat_id,
                             timeout_minutes=timeout_min,
+                            model=step_model,
                         )
                         # Update session_key from placeholder to actual value
                         # (use update_task to avoid resetting started_at)
@@ -1060,6 +1069,7 @@ Report results to: {chat_id}
             self.store.insert_step(
                 plan.id, step_num, ns["title"], ns["prompt"], deps,
                 timeout_minutes=ns.get("timeout_minutes"),
+                model=ns.get("model"),
             )
 
         # Auto-advance if plan is active

--- a/src/luna_os/store/base.py
+++ b/src/luna_os/store/base.py
@@ -174,6 +174,7 @@ class StorageBackend(ABC):
         prompt: str,
         depends_on: list[int] | None = None,
         timeout_minutes: int | None = None,
+        model: str | None = None,
     ) -> None:
         """Insert a single pending step."""
 

--- a/src/luna_os/store/postgres.py
+++ b/src/luna_os/store/postgres.py
@@ -369,12 +369,13 @@ class PostgresBackend(StorageBackend):
             self._execute(
                 """INSERT INTO plan_steps
                    (plan_id, step_num, title, prompt, status,
-                    depends_on, timeout_minutes)
-                   VALUES (%s, %s, %s, %s, 'pending', %s, %s)""",
+                    depends_on, timeout_minutes, model)
+                   VALUES (%s, %s, %s, %s, 'pending', %s, %s, %s)""",
                 (
                     plan_id, i, s.get("title", ""),
                     s.get("prompt", ""), deps,
                     s.get("timeout_minutes"),
+                    s.get("model"),
                 ),
             )
         return self.get_plan(plan_id)  # type: ignore[return-value]
@@ -594,15 +595,17 @@ class PostgresBackend(StorageBackend):
         prompt: str,
         depends_on: list[int] | None = None,
         timeout_minutes: int | None = None,
+        model: str | None = None,
     ) -> None:
         # Filter out self-referencing dependencies
         clean_deps = [d for d in (depends_on or []) if d != step_num]
         self._execute(
             """INSERT INTO plan_steps
                (plan_id, step_num, title, prompt, status,
-                depends_on, timeout_minutes)
-               VALUES (%s, %s, %s, %s, 'pending', %s, %s)""",
-            (plan_id, step_num, title, prompt, clean_deps, timeout_minutes),
+                depends_on, timeout_minutes, model)
+               VALUES (%s, %s, %s, %s, 'pending', %s, %s, %s)""",
+            (plan_id, step_num, title, prompt, clean_deps,
+             timeout_minutes, model),
         )
 
     # -- Events ----------------------------------------------------------------

--- a/src/luna_os/timeline.py
+++ b/src/luna_os/timeline.py
@@ -30,6 +30,10 @@ def steps_to_graph_data(plan: Plan) -> list[dict[str, Any]]:
         }
         if s.task_id:
             entry["tid"] = s.task_id
+        if s.timeout_minutes:
+            entry["timeout"] = s.timeout_minutes
+        if s.model:
+            entry["model"] = s.model
         steps_data.append(entry)
     return steps_data
 
@@ -194,8 +198,13 @@ steps.forEach(s => {{
         ? `<span class="node-tid">${{s.tid}}</span>` : '';
     const dur = (s.status === 'running' && s.duration)
         ? `<span class="node-duration">\\u23f1${{s.duration}}</span>` : '';
-    const meta = (tid || dur)
-        ? `<div class="node-meta">${{tid}}${{dur}}</div>` : '';
+    const timeout = s.timeout
+        ? `<span class="node-tid">\\u23f0${{s.timeout}}m</span>` : '';
+    const model = s.model
+        ? `<span class="node-tid">\\U0001f916${{s.model}}</span>` : '';
+    const metaParts = [tid, dur, timeout, model].filter(Boolean);
+    const meta = metaParts.length
+        ? `<div class="node-meta">${{metaParts.join(' ')}}</div>` : '';
     el.innerHTML = `
         <div class="node-icon">S${{s.id}}</div>
         <div class="node-body">

--- a/src/luna_os/types.py
+++ b/src/luna_os/types.py
@@ -134,6 +134,7 @@ class Step:
     result: str | None = None
     depends_on: list[int] = field(default_factory=list)
     timeout_minutes: int | None = None
+    model: str | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
 

--- a/tests/memory_store.py
+++ b/tests/memory_store.py
@@ -216,6 +216,7 @@ class MemoryBackend(StorageBackend):
                     status=StepStatus.PENDING,
                     depends_on=deps,
                     timeout_minutes=s.get("timeout_minutes"),
+                    model=s.get("model"),
                 )
             )
         plan = Plan(
@@ -355,6 +356,7 @@ class MemoryBackend(StorageBackend):
         prompt: str,
         depends_on: list[int] | None = None,
         timeout_minutes: int | None = None,
+        model: str | None = None,
     ) -> None:
         plan = self._plans.get(plan_id)
         if plan:
@@ -367,6 +369,7 @@ class MemoryBackend(StorageBackend):
                     status=StepStatus.PENDING,
                     depends_on=depends_on or [],
                     timeout_minutes=timeout_minutes,
+                    model=model,
                 )
             )
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -14,6 +14,7 @@ class _NoopRunner(AgentRunner):
         self, task_id: str, prompt: str,
         session_label: str = "", reply_chat_id: str = "",
         timeout_minutes: int | None = None,
+        model: str | None = None,
     ) -> str:
         return session_label or f"task-{task_id}"
 

--- a/tests/test_spawn_rollback.py
+++ b/tests/test_spawn_rollback.py
@@ -18,6 +18,7 @@ class FakeRunner(AgentRunner):
         self, task_id: str, prompt: str,
         session_label: str = "", reply_chat_id: str = "",
         timeout_minutes: int | None = None,
+        model: str | None = None,
     ) -> str:
         if self._fail:
             raise RuntimeError("simulated spawn failure")


### PR DESCRIPTION
三个改进：

1. **每步可指定模型** — step 定义里加 `model` 字段，传给 Gateway RPC
2. **完整 plan 上下文** — spawn prompt 不再只给最近 3 个已完成步骤，而是展示全部步骤的状态、依赖、结果。并行步骤标注 (parallel)，当前步骤标注 ← YOU。明确指令：不要重复其他步骤的工作
3. **规划图显示元数据** — 每个节点显示 ⏰超时 和 🤖模型

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added model configuration capability for individual plan steps, allowing fine-grained model selection per step
  * Enhanced plan visualization to display comprehensive step-specific information including model and timeout
  * Improved agent execution with per-step model context propagation
  * Enriched plan overview prompts with full step details, dependencies, and status annotations
  * Better session key tracking for accurate task monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->