### PR TITLE
fix: remove unsupported 'model' param from Gateway agent RPC

### DIFF
--- a/src/luna_os/agents/openclaw.py
+++ b/src/luna_os/agents/openclaw.py
@@ -60,8 +60,10 @@ class OpenClawRunner(AgentRunner):
             "lane": "subagent",
             "timeout": timeout_sec,
         }
-        if model:
-            params["model"] = model
+        # Note: Gateway agent RPC does not support 'model' parameter yet
+        # Model override must be done via session-level config or /model command
+        # if model:
+        #     params["model"] = model
 
         cmd = [
             self._binary, "gateway", "call", "agent",


### PR DESCRIPTION
Gateway's agent RPC does not accept 'model' parameter, causing spawn failures with 'unexpected property' error.

This PR comments out the model param until Gateway adds support for per-agent model override.

**Root cause**: planner._start_ready_steps() calls agent_runner.spawn() with model parameter, but Gateway's agent RPC schema doesn't include 'model' field.

**Impact**: All planner steps were failing to spawn with error: `invalid agent params: at root: unexpected property 'model'`

**Fix**: Comment out model param in openclaw.py spawn() method.

**Future work**: If per-step model override is needed, Gateway must add 'model' to agent RPC schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified model selection behavior: model overrides must now be configured through session settings or the `/model` command rather than runtime parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->