### PR TITLE
feat: watchdog — extensible task health monitoring

### DIFF
--- a/src/luna_os/cli.py
+++ b/src/luna_os/cli.py
@@ -35,6 +35,9 @@ Usage:
   luna-os intercept serve [--port 8280] [--upstream URL]
   luna-os intercept test "message text"
   luna-os intercept list-commands
+
+  luna-os watchdog run [--dry-run] [--verbose]
+  luna-os watchdog status
 """
 
 from __future__ import annotations
@@ -375,9 +378,28 @@ def main() -> None:
         from luna_os.session_overview import main as overview_main
 
         overview_main()
+    elif top == "watchdog":
+        _watchdog_cli(rest)
     else:
         print(f"Unknown command: {top}", file=sys.stderr)
         print(__doc__)
+        sys.exit(1)
+
+
+def _watchdog_cli(args: list[str]) -> None:
+    """Watchdog subcommand handler."""
+    from luna_os.watchdog.runner import run, status
+
+    if not args or args[0] in ("run", "check"):
+        dry_run = "--dry-run" in args
+        verbose = "--verbose" in args or "-v" in args
+        alerts = run(dry_run=dry_run, verbose=verbose)
+        if not alerts:
+            print("✅ All clear — no issues found")
+    elif args[0] == "status":
+        status()
+    else:
+        print(f"Usage: luna-os watchdog [run|status] [--dry-run] [--verbose]")
         sys.exit(1)
 
 

--- a/src/luna_os/interceptor/handlers.py
+++ b/src/luna_os/interceptor/handlers.py
@@ -402,7 +402,7 @@ async def handle_share(user_text: str, result: InterceptResult) -> dict[str, Any
         )
     
     # Call create_share_from_last_new.py
-    script_path = "/home/ubuntu/.openclaw/workspace/projects/luna-share/create_share_from_last_new.py"
+    script_path = "/home/ubuntu/repos/luna-share/create_share_from_last_new.py"
     logger.info(f"[share] Calling script with session_id: {session_id}, chat_id: {chat_id}")
     
     try:

--- a/src/luna_os/watchdog/__init__.py
+++ b/src/luna_os/watchdog/__init__.py
@@ -1,0 +1,1 @@
+# Luna OS Watchdog — extensible task health monitoring

--- a/src/luna_os/watchdog/alerter.py
+++ b/src/luna_os/watchdog/alerter.py
@@ -1,0 +1,35 @@
+"""Send watchdog alerts via openclaw system event."""
+from __future__ import annotations
+import logging
+import subprocess
+from .models import Alert, Severity
+
+logger = logging.getLogger(__name__)
+
+SEVERITY_EMOJI = {
+    Severity.INFO: "ℹ️",
+    Severity.WARN: "⚠️",
+    Severity.CRITICAL: "🚨",
+}
+
+
+def send_alerts(alerts: list[Alert]):
+    """Send alerts as a single wake event to Luna."""
+    if not alerts:
+        return
+
+    lines = ["🐕 Watchdog 检测到异常：", ""]
+    for a in alerts:
+        emoji = SEVERITY_EMOJI.get(a.severity, "⚠️")
+        lines.append(f"{emoji} [{a.check_name}] {a.message}")
+
+    text = "\n".join(lines)
+    logger.info(f"Sending {len(alerts)} alert(s)")
+
+    try:
+        subprocess.run(
+            ["openclaw", "system", "event", "--text", text, "--mode", "now"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception as e:
+        logger.error(f"Failed to send alert: {e}")

--- a/src/luna_os/watchdog/checks/__init__.py
+++ b/src/luna_os/watchdog/checks/__init__.py
@@ -1,0 +1,1 @@
+# Watchdog checks package — drop a .py file here to add a new check

--- a/src/luna_os/watchdog/checks/dead_agents.py
+++ b/src/luna_os/watchdog/checks/dead_agents.py
@@ -1,0 +1,60 @@
+"""Check for sub-agents that finished but didn't report back."""
+from __future__ import annotations
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone, timedelta
+from ..models import Alert, Severity
+
+NAME = "dead_agents"
+logger = logging.getLogger(__name__)
+
+
+def check(db) -> list[Alert]:
+    """Find tasks with running status but whose agent session is no longer active."""
+    alerts = []
+
+    # Get running tasks that have a session/agent associated
+    rows = db.execute(
+        """
+        SELECT id, description, status, updated_at, source_chat
+        FROM tasks
+        WHERE status = 'running'
+          AND updated_at < %s
+        """,
+        (datetime.now(timezone.utc) - timedelta(minutes=3),)
+    )
+
+    # Get active sessions
+    active_sessions = set()
+    try:
+        proc = subprocess.run(
+            ["openclaw", "sessions", "--active", "10", "--json"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if proc.returncode == 0:
+            data = json.loads(proc.stdout)
+            sessions = data.get("sessions", data) if isinstance(data, dict) else data
+            for s in sessions:
+                key = s.get("key", s.get("sessionKey", ""))
+                active_sessions.add(key)
+    except Exception as e:
+        logger.warning(f"Failed to list sessions: {e}")
+        return []  # Can't check without session data
+
+    for row in rows:
+        task_id = row["id"]
+        # Check if there's an active session for this task
+        has_session = any(task_id in s for s in active_sessions)
+        if not has_session:
+            mins = int((datetime.now(timezone.utc) - row["updated_at"]).total_seconds() / 60)
+            desc = (row["description"] or "")[:60]
+            alerts.append(Alert(
+                check_name=NAME,
+                key=f"dead_agent:{task_id}",
+                message=f"任务 {task_id} 状态为 running 但无活跃 session ({mins} 分钟): {desc}",
+                severity=Severity.CRITICAL,
+                context={"task_id": task_id, "chat_id": row.get("source_chat")},
+            ))
+
+    return alerts

--- a/src/luna_os/watchdog/checks/stale_tasks.py
+++ b/src/luna_os/watchdog/checks/stale_tasks.py
@@ -1,0 +1,38 @@
+"""Check for tasks stuck in 'running' state too long."""
+from __future__ import annotations
+from datetime import datetime, timezone, timedelta
+from ..models import Alert, Severity
+
+NAME = "stale_tasks"
+STALE_MINUTES = 15
+
+
+def check(db) -> list[Alert]:
+    """Find tasks that have been running for too long without updates."""
+    alerts = []
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=STALE_MINUTES)
+
+    rows = db.execute(
+        """
+        SELECT id, description, status, updated_at, source_chat
+        FROM tasks
+        WHERE status = 'running'
+          AND updated_at < %s
+        ORDER BY updated_at ASC
+        """,
+        (cutoff,)
+    )
+
+    for row in rows:
+        task_id = row["id"]
+        mins = int((datetime.now(timezone.utc) - row["updated_at"]).total_seconds() / 60)
+        desc = (row["description"] or "")[:60]
+        alerts.append(Alert(
+            check_name=NAME,
+            key=f"stale_task:{task_id}",
+            message=f"任务 {task_id} 已运行 {mins} 分钟无更新: {desc}",
+            severity=Severity.WARN,
+            context={"task_id": task_id, "chat_id": row.get("source_chat")},
+        ))
+
+    return alerts

--- a/src/luna_os/watchdog/checks/stuck_plans.py
+++ b/src/luna_os/watchdog/checks/stuck_plans.py
@@ -1,0 +1,73 @@
+"""Check for plans with completed steps but next steps not started."""
+from __future__ import annotations
+import json
+from datetime import datetime, timezone, timedelta
+from ..models import Alert, Severity
+
+NAME = "stuck_plans"
+STUCK_MINUTES = 5
+
+
+def check(db) -> list[Alert]:
+    """Find active plans where a step is done but the next dependent step hasn't started."""
+    alerts = []
+
+    plans = db.execute(
+        "SELECT id, chat_id, goal, status, updated_at FROM plans WHERE status = 'active'"
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=STUCK_MINUTES)
+
+    for plan in plans:
+        plan_id = plan["id"]
+
+        steps = db.execute(
+            """
+            SELECT step_num, status, task_id, title, depends_on, completed_at
+            FROM plan_steps
+            WHERE plan_id = %s
+            ORDER BY step_num
+            """,
+            (plan_id,)
+        )
+
+        step_list = list(steps)
+        done_nums = {s["step_num"] for s in step_list if s["status"] == "done"}
+
+        for s in step_list:
+            if s["status"] != "pending":
+                continue
+
+            deps = s.get("depends_on") or []
+            if isinstance(deps, str):
+                try:
+                    deps = json.loads(deps)
+                except Exception:
+                    deps = []
+
+            if not deps:
+                continue
+
+            all_deps_done = all(d in done_nums for d in deps)
+            if not all_deps_done:
+                continue
+
+            # All deps done — check how long ago
+            dep_done_times = [
+                st["completed_at"] for st in step_list
+                if st["step_num"] in deps and st["completed_at"] is not None
+            ]
+
+            if dep_done_times and max(dep_done_times) < cutoff:
+                mins = int((datetime.now(timezone.utc) - max(dep_done_times)).total_seconds() / 60)
+                title = (s["title"] or "")[:50]
+                goal = (plan["goal"] or "")[:40]
+                alerts.append(Alert(
+                    check_name=NAME,
+                    key=f"stuck_plan:{plan_id}:step:{s['step_num']}",
+                    message=f"Plan {plan_id} ({goal}) 步骤 {s['step_num']} 依赖已完成 {mins} 分钟但未启动: {title}",
+                    severity=Severity.WARN,
+                    context={"plan_id": plan_id, "chat_id": plan.get("chat_id"), "step_num": s["step_num"]},
+                ))
+
+    return alerts

--- a/src/luna_os/watchdog/models.py
+++ b/src/luna_os/watchdog/models.py
@@ -1,0 +1,58 @@
+"""Watchdog alert model and dedup logic."""
+from __future__ import annotations
+import json
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+
+class Severity(Enum):
+    INFO = "info"
+    WARN = "warn"
+    CRITICAL = "critical"
+
+
+@dataclass
+class Alert:
+    check_name: str
+    key: str  # dedup key, e.g. "stale_task:tid-0225-10"
+    message: str
+    severity: Severity = Severity.WARN
+    context: dict = field(default_factory=dict)
+
+
+# Dedup state file
+DEDUP_FILE = Path.home() / ".openclaw" / "share" / "watchdog_dedup.json"
+COOLDOWN_SECONDS = 15 * 60  # 15 minutes
+
+
+def _load_dedup() -> dict:
+    if DEDUP_FILE.exists():
+        try:
+            return json.loads(DEDUP_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_dedup(state: dict):
+    DEDUP_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DEDUP_FILE.write_text(json.dumps(state))
+
+
+def filter_dedup(alerts: list[Alert]) -> list[Alert]:
+    """Remove alerts that were already fired within cooldown period."""
+    state = _load_dedup()
+    now = time.time()
+    new_alerts = []
+    for a in alerts:
+        last_fired = state.get(a.key, 0)
+        if now - last_fired > COOLDOWN_SECONDS:
+            new_alerts.append(a)
+            state[a.key] = now
+    # Clean old entries (> 24h)
+    state = {k: v for k, v in state.items() if now - v < 86400}
+    _save_dedup(state)
+    return new_alerts

--- a/src/luna_os/watchdog/runner.py
+++ b/src/luna_os/watchdog/runner.py
@@ -1,0 +1,117 @@
+"""Watchdog runner — discovers and executes all checks, sends alerts."""
+from __future__ import annotations
+import importlib
+import logging
+import os
+import pkgutil
+import sys
+from pathlib import Path
+
+from . import checks as checks_pkg
+from .models import Alert, filter_dedup
+from .alerter import send_alerts
+
+logger = logging.getLogger(__name__)
+
+
+def _get_db():
+    """Get a database connection that returns dicts."""
+    import psycopg2
+    url = os.environ.get("DATABASE_URL", "")
+    if not url:
+        raise RuntimeError("DATABASE_URL not set")
+    conn = psycopg2.connect(url)
+    conn.autocommit = True  # Each query is independent
+    return conn
+
+
+class _DictCursorDB:
+    """Thin wrapper that provides db.execute() returning list of dicts."""
+    def __init__(self, conn):
+        self.conn = conn
+
+    def execute(self, query, params=None):
+        import psycopg2.extras
+        with self.conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(query, params)
+            return cur.fetchall()
+
+
+def discover_checks():
+    """Auto-discover all check modules in the checks/ package."""
+    check_modules = []
+    checks_path = Path(checks_pkg.__file__).parent
+
+    for importer, modname, ispkg in pkgutil.iter_modules([str(checks_path)]):
+        if modname.startswith("_"):
+            continue
+        try:
+            mod = importlib.import_module(f".checks.{modname}", package="luna_os.watchdog")
+            if hasattr(mod, "check"):
+                check_modules.append(mod)
+                logger.debug(f"Loaded check: {modname}")
+        except Exception as e:
+            logger.warning(f"Failed to load check {modname}: {e}")
+
+    return check_modules
+
+
+def run(dry_run: bool = False, verbose: bool = False) -> list[Alert]:
+    """Run all checks, dedup, and send alerts. Returns alerts found."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s [watchdog] %(message)s")
+
+    modules = discover_checks()
+    logger.info(f"Discovered {len(modules)} check(s): {[m.NAME for m in modules if hasattr(m, 'NAME')]}")
+
+    conn = _get_db()
+    db = _DictCursorDB(conn)
+
+    all_alerts = []
+    for mod in modules:
+        name = getattr(mod, "NAME", mod.__name__)
+        try:
+            alerts = mod.check(db)
+            if alerts:
+                logger.info(f"  {name}: {len(alerts)} alert(s)")
+            else:
+                logger.debug(f"  {name}: OK")
+            all_alerts.extend(alerts)
+        except Exception as e:
+            logger.error(f"  {name}: ERROR — {e}")
+
+    conn.close()
+
+    # Dedup
+    new_alerts = filter_dedup(all_alerts)
+    logger.info(f"Total: {len(all_alerts)} alert(s), {len(new_alerts)} new (after dedup)")
+
+    if new_alerts and not dry_run:
+        send_alerts(new_alerts)
+    elif new_alerts and dry_run:
+        for a in new_alerts:
+            print(f"  [{a.severity.value}] {a.message}")
+
+    return new_alerts
+
+
+def status():
+    """Show current watchdog status — recent alerts and check health."""
+    from .models import _load_dedup
+    import time
+
+    state = _load_dedup()
+    now = time.time()
+
+    print(f"Watchdog status — {len(state)} tracked alert(s)")
+    print()
+
+    if not state:
+        print("  No recent alerts. All clear. ✅")
+        return
+
+    for key, ts in sorted(state.items(), key=lambda x: x[1], reverse=True):
+        age_min = int((now - ts) / 60)
+        cooldown_left = max(0, 15 - age_min)
+        status = f"(cooldown {cooldown_left}m)" if cooldown_left > 0 else "(can re-fire)"
+        print(f"  {key}: last fired {age_min}m ago {status}")


### PR DESCRIPTION
## 解决的问题
Carl 反馈任务经常卡住需要手动戳才能推进。Watchdog 每 3 分钟自动检测异常，发 wake event 触发 Luna 处理。

## 架构
```
luna_os/watchdog/
├── runner.py      # 主循环：发现 checks，执行，汇总告警
├── models.py      # Alert 模型 + 去重逻辑（15min 冷却）
├── alerter.py     # 发 openclaw system event
└── checks/        # 插件目录，自动发现
    ├── stale_tasks.py   # 任务 running >15min 无更新
    ├── stuck_plans.py   # Plan 步骤依赖完成但未启动 >5min
    └── dead_agents.py   # 任务 running 但无活跃 session
```

## 扩展方式
在 `checks/` 目录下新建 .py 文件，实现 `check(db) -> list[Alert]` 函数即可。

## 成本
- 正常时：零 LLM 调用（纯 SQL 查询）
- 异常时：1 次 wake event（带精确上下文）

## CLI
- `luna-os watchdog run [--dry-run] [--verbose]`
- `luna-os watchdog status`

## Crontab
```
*/3 * * * * bash -c 'set -a; source ~/.openclaw/workspace/.env; set +a; luna-os watchdog run'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added watchdog CLI command with `run`, `status`, and `--dry-run` options to monitor system health.
  * Detects stale tasks, stuck plan steps, and dead agents, sending alert notifications automatically.
  * Preview alerts before sending using dry-run mode; view alert history and cooldown status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->